### PR TITLE
Explicitly set restart policy for user pods

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,9 @@ binderhub:
         #  tag: a-tag
 
     hub:
-      extraConfig: {}
+      extraConfig:
+        neverRestart: |
+          c.KubeSpawner.extra_pod_config.update({'restart_policy': 'Never'})
       activeServerLimit: 5
       networkPolicy:
         enabled: false


### PR DESCRIPTION
This has been deployed.

Let's see if this stops user pods from being restarted when they are culled/shutdown for inactivity.